### PR TITLE
Fix error message when missing *.depend.psd1

### DIFF
--- a/PSDepend/Public/Invoke-PSDepend.ps1
+++ b/PSDepend/Public/Invoke-PSDepend.ps1
@@ -206,7 +206,7 @@ Function Invoke-PSDepend {
                 }
                 else
                 {
-                    Write-Warning "No *.depend.ps1 files found under [$PathItem]"
+                    Write-Warning "No *.depend.psd1 files found under [$PathItem]"
                 }
             }
             $GetPSDependParams.add('Path',$DependencyFiles)


### PR DESCRIPTION
Fixes misleading error message when dependency file has been saves erroneously as *.depend.ps1 instead of *.depend.psd1