### PR TITLE
fix: use standard Package query url format

### DIFF
--- a/PSDepend/Private/Find-NugetPackage.ps1
+++ b/PSDepend/Private/Find-NugetPackage.ps1
@@ -22,17 +22,17 @@ function Find-NugetPackage {
     if($IsLatest)
     {
         Write-Verbose "Searching for latest [$name] module"
-        $URI = "${PackageSourceUrl}Packages?`$filter=Id eq '$name' and IsLatestVersion"
+        $URI = "${PackageSourceUrl}Packages()?`$filter=Id eq '$name' and IsLatestVersion"
     }
     elseif($PSBoundParameters.ContainsKey($Version))
     {
         Write-Verbose "Searching for version [$version] of [$name]"
-        $URI = "${PackageSourceUrl}Packages?`$filter=Id eq '$name' and Version eq '$Version'"
+        $URI = "${PackageSourceUrl}Packages()?`$filter=Id eq '$name' and Version eq '$Version'"
     }
     else
     {
         Write-Verbose "Searching for all versions of [$name] module"
-        $URI = "${PackageSourceUrl}Packages?`$filter=Id eq '$name'"
+        $URI = "${PackageSourceUrl}Packages()?`$filter=Id eq '$name'"
     }
 
     $headers = @{}


### PR DESCRIPTION
many nuget server don't care whether the Packages query
is executed with  as `Pacakges()` or as `Packages`. But Artifactory
by JFrog needs the braces.
Default query adjusted to always use `Packages()` query format which
should work for all nuget server, includin JFrog Artifactory.