### PR TITLE
PSGalleryModule: Use path instead of module name

### DIFF
--- a/PSDepend2/PSDependScripts/PSGalleryModule.ps1
+++ b/PSDepend2/PSDependScripts/PSGalleryModule.ps1
@@ -249,7 +249,7 @@ if($Existing)
     {
         Write-Verbose "You have the requested version [$Version] of [$Name]"
         # Conditional import
-        Import-PSDependModule -Name $ModuleName -Action $PSDependAction -Version $ExistingVersion
+        Import-PSDependModule -Name $Existing.Path -Action $PSDependAction -Version $ExistingVersion
 
         if($PSDependAction -contains 'Test')
         {
@@ -277,7 +277,7 @@ if($Existing)
     {
         Write-Verbose "You have the latest version of [$Name], with installed version [$ExistingVersion] and PSGallery version [$GalleryVersion]"
         # Conditional import
-        Import-PSDependModule -Name $ModuleName -Action $PSDependAction -Version $ExistingVersion
+        Import-PSDependModule -Name $Existing.Path -Action $PSDependAction -Version $ExistingVersion
 
         if($PSDependAction -contains 'Test')
         {

--- a/Tests/PSModuleGallery.Type.Tests.ps1
+++ b/Tests/PSModuleGallery.Type.Tests.ps1
@@ -383,6 +383,7 @@ InModuleScope ('{0}' -f $ENV:BHProjectName) {
             Mock Get-Module {
                 [pscustomobject]@{
                     Version = '1.2.5'
+                    Path    = "C:\dummy\path"
                 }
             }
             Mock Find-Module {


### PR DESCRIPTION
Hi,

thanks for keeping `PSDepend` alive!

Today I used the "virtual env" approach to install modules in a separate folder.
Installation & testing was fine, but import failed:
```ps
VERBOSE: Populating RepositorySourceLocation property for module IntuneWin32App.
VERBOSE: Found existing module [IntuneWin32App]
VERBOSE: You have the requested version [1.3.3] of [IntuneWin32App]
VERBOSE: Importing [.DependencyFolder\IntuneWin32App]

The specified module '.DependencyFolder\IntuneWin32App' with version '1.3.3' was not loaded because no valid module file was found in any module directory.
```

In my example that would mean that
* `IntuneWin32App` is the (real) name of the module
* `.DependencyFolder\IntuneWin32App` is the `ModuleName` (virtual env folder & module name) (according to `PSDepend`

The folder structure etc looks fine (similar to globally installed modules)

It looks like `PSDepend` tries to first find the installed module and then load it.
`Get-Module` accepts a relative path, `Import-Module` not (??).

Because the existing module should be loaded anyway (and we know where it is), I changed it to use the full path (instead of the module name).

I hope that this assumption is correct, but it works for me.

best regards,

Semtyre

